### PR TITLE
Make script shebang portable

### DIFF
--- a/rust-ctags
+++ b/rust-ctags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$1" == "" ]]; then
     echo Usage: rust-ctags dirs...


### PR DESCRIPTION
Makes the script compatible with platforms that keep `bash` elsewhere.